### PR TITLE
docs: update docs to use pgrx

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -9,9 +9,9 @@ We've got cake!
 
 # Steps
 
-1. Install `cargo-pgx`, with `cargo install cargo-pgx --locked --version =0.7.4`
+1. Install `cargo-pgrx`, with `cargo install cargo-pgrx --locked --version =0.7.4`
 
-2. Configure `cargo-pgx`, with `cargo pgx init --pgNN=download`
+2. Configure `cargo-pgrx`, with `cargo pgrx init --pgNN=download`
 
    Where `NN` is the major version of the Postgres version you want to use as your "primary" test platform.
 
@@ -20,7 +20,7 @@ We've got cake!
 
 3. Hack away to your heart's content.
 
-4. To run the test suite, run `cargo pgx test --features pgNN pgNN`
+4. To run the test suite, run `cargo pgrx test --features pgNN pgNN`
 
-5. To get a running Postgres with your current extension available for use, run `cargo pgx run --features pgNN pgNN`.
+5. To get a running Postgres with your current extension available for use, run `cargo pgrx run --features pgNN pgNN`.
    It'll print the port number that your temporary Postgres instance is listening on.

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -41,13 +41,13 @@ If you are running a packaged version of PostgreSQL, these may be in a package t
 For example, for Debian/Ubuntu, the server-side development headers are in a package named **`postgresql-server-dev-14`** (switch out the `14` for your PostgreSQL major version, if you running an older version).
 
 
-## Install and Configure `cargo-pgx`
+## Install and Configure `cargo-pgrx`
 
-The `cargo-pgx` package is a tool for building PostgreSQL extensions in Rust.
+The `cargo-pgrx` package is a tool for building PostgreSQL extensions in Rust.
 
-1. Install `cargo-pgx`, with `cargo install cargo-pgrx --locked --version=0.12.8`
+1. Install `cargo-pgrx`, with `cargo install cargo-pgrx --locked --version=0.12.8`
 
-2. Configure `cargo-pgx`, with `cargo pgx init --pg14=$(which pg_config)`
+2. Configure `cargo-pgrx`, with `cargo pgrx init --pg14=$(which pg_config)`
 
    If you're running an older PostgreSQL major version, replace `14` with the major version you're using.
 
@@ -65,7 +65,7 @@ cd pg_enquo
 Now you can now build and install `pg_enquo` with this one weird trick:
 
 ```sh
-cargo pgx install --features pg14 --release
+cargo pgrx install --features pg14 --release
 ```
 
 If you're running an older PostgreSQL major version, replace `14` with the major version you're using.

--- a/pg_enquo.control
+++ b/pg_enquo.control
@@ -1,4 +1,4 @@
-comment = 'pg_enquo:  Created by pgx'
+comment = 'pg_enquo:  Created by pgrx'
 default_version = '0.0'
 module_pathname = '$libdir/pg_enquo'
 relocatable = false


### PR DESCRIPTION
Noticed I hadn't updated docs since bumping everything to use pgrx. Ran into this problem while installing the extension for some local development.